### PR TITLE
Closes #5 and small bugfixes

### DIFF
--- a/javascript/nodejs/nodeclient/bin/maia-client
+++ b/javascript/nodejs/nodeclient/bin/maia-client
@@ -2,11 +2,10 @@
 
 var Client = require('../lib/maia-client').Client;
 
-var client = new Client({
+var client = new Client('ws://127.0.0.1:1337',{
   name: "default-client"
 });
 
-client.connect('ws://127.0.0.1:1337');
 client.subscribe('**', function(json){
     client.logger.debug('Received:', json);
 });
@@ -17,4 +16,4 @@ client.subscribe('test', fn);
 
 setTimeout(function(){
     client.unsubscribe('test', fn);
-}, 1000);
+}, 10000);

--- a/javascript/nodejs/nodeclient/package.json
+++ b/javascript/nodejs/nodeclient/package.json
@@ -7,7 +7,7 @@
     "websockets",
     "maia"
   ],
-  "version": "0.3.0",
+  "version": "0.4.0",
   "bugs": {
     "url": "http://github.com/gsi-upm/Maia/issues"
   },
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "simple-colourful-logger": "*",
-    "websocket": ">=1.0.8"
+    "ws": ">=0.4"
   },
   "devDependencies": {}
 }

--- a/nodeserver/package.json
+++ b/nodeserver/package.json
@@ -2,7 +2,7 @@
   "author": "J. Fernando Sánchez (balkian)",
   "name": "maia-server",
   "description": "Maia Server Implementation (http://gsi.dit.upm.es).",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "repository": {
     "url": "git://github.com/gsi-upm/Maia"
   },
@@ -11,7 +11,7 @@
     "maiaserver": "./bin/maia-server"
   },
   "dependencies": {
-    "websocket": ">=1.0.8",
+    "ws": ">=0.4",
     "express": ">=3.1.0",
     "cli-color": "*",
     "simple-colourful-logger": "*"


### PR DESCRIPTION
A small regression happened in the last commit due to which event
names weren't properly split.

Now we use WS instead of Websocket-Node. The constructor of WS initializes the socket with URL, and there isn't any separate .connect method. I had to add a ws socket attribute in the clients instead of inheriting from it.
