### PR TITLE
Deattach bodyParser of express framework

### DIFF
--- a/nodeserver/lib/webhook-transport.js
+++ b/nodeserver/lib/webhook-transport.js
@@ -6,6 +6,7 @@
 // http://github.com/gsi-upm
 
 var express = require('express');
+var bodyParser = require('body-parser');
 var http = require('http');
 var path = require('path');
 var MaiaTransport = require('./maia-transport').MaiaTransport;
@@ -23,8 +24,8 @@ function WHTransport(port, servestatic, app, levels){
     if(servestatic){
         self.staticpath = path.resolve(__dirname, '../public');
         self.app.use(express.static(self.staticpath));
-    }
-    self.app.use(express.bodyParser());
+    }    
+    self.app.use(bodyParser());
 }
 
 WHTransport.prototype = Object.create(MaiaTransport.prototype);


### PR DESCRIPTION
It seems bodyParser (among others) no longer come in the bundle lib of express. So it gives an error when trying to launch maia server without specifically installing body-parser.

Apart from that, when run, it is no longer part of the express module, so it cannot be called as with the former version. The Pull request solve this issue. Although it has not been tested application wide.

On the other hand, this pull request does not changes dependencies and it **must also be done**.
